### PR TITLE
Training improvements

### DIFF
--- a/iit/model_pairs/base_model_pair.py
+++ b/iit/model_pairs/base_model_pair.py
@@ -238,7 +238,6 @@ class BaseModelPair(ABC):
         self,
         train_set: IITDataset,
         test_set: IITDataset,
-        optimizer_cls: Type[t.optim.Optimizer] = t.optim.Adam,
         epochs: int = 1000,
         use_wandb: bool = False,
         wandb_name_suffix: str = "",
@@ -261,7 +260,7 @@ class BaseModelPair(ABC):
 
         early_stop = training_args["early_stop"]
 
-        optimizer = optimizer_cls(self.ll_model.parameters(), **training_args['optimizer_kwargs'])
+        optimizer = training_args['optimizer_cls'](self.ll_model.parameters(), **training_args['optimizer_kwargs'])
         loss_fn = self.loss_fn
         scheduler_cls = training_args.get("lr_scheduler", None)
         scheduler_kwargs = training_args.get("scheduler_kwargs", {})

--- a/iit/model_pairs/base_model_pair.py
+++ b/iit/model_pairs/base_model_pair.py
@@ -20,10 +20,10 @@ from iit.utils.iit_dataset import IITDataset
 from iit.utils.index import Ix, TorchIndex
 from iit.utils.metric import MetricStoreCollection, MetricType
 
-def in_notebook():
+def in_notebook() -> bool:
     try:
         # This will only work in Jupyter notebooks
-        shell = get_ipython().__class__.__name__
+        shell = get_ipython().__class__.__name__ # type: ignore
         if shell == 'ZMQInteractiveShell':
             return True  # Jupyter notebook or qtconsole
         elif shell == 'TerminalInteractiveShell':
@@ -387,7 +387,7 @@ class BaseModelPair(ABC):
         optimizer: t.optim.Optimizer,
         use_wandb: bool = False,
         print_metrics: bool = True,
-        ) -> None:
+        ) -> str:
         
         # Print the current epoch's metrics
         current_epoch_log = f"lr: {optimizer.param_groups[0]['lr']:.2e}, "

--- a/iit/model_pairs/base_model_pair.py
+++ b/iit/model_pairs/base_model_pair.py
@@ -410,6 +410,6 @@ class BaseModelPair(ABC):
         
         return current_epoch_log
 
-    @abstractmethod
     def _run_epoch_extras(self, epoch_number: int) -> None:
+        """ Optional method for running extra code at the end of each epoch """
         pass

--- a/iit/model_pairs/iit_behavior_model_pair.py
+++ b/iit/model_pairs/iit_behavior_model_pair.py
@@ -145,13 +145,13 @@ class IITBehaviorModelPair(IITModelPair):
 
         # compute behavioral accuracy
         base_x, base_y = base_input[0:2]
-        output = self.ll_model(base_x)[label_idx.as_index] #convert ll logits -> one-hot max label
+        output = self.ll_model(base_x)
         if self.hl_model.is_categorical():
             top1 = t.argmax(output, dim=-1)
-            if output.shape[-1] == base_y.shape[-1]:
+            if output.shape == base_y.shape:
                 # To handle the case when labels are one-hot
                 # TODO: is there a better way?
-                base_y = t.argmax(base_y, dim=-1).squeeze()
+                base_y = t.argmax(base_y, dim=-1)
             accuracy = (top1 == base_y).float().mean()
         else:
             accuracy = ((output - base_y).abs() < atol).float().mean()

--- a/iit/model_pairs/iit_behavior_model_pair.py
+++ b/iit/model_pairs/iit_behavior_model_pair.py
@@ -20,7 +20,7 @@ class IITBehaviorModelPair(IITModelPair):
             ):
         default_training_args = {
             "atol": 5e-2,
-            "use_single_loss": False,
+            "use_single_loss": True,
             "iit_weight": 1.0,
             "behavior_weight": 1.0,
             "iit_weight_schedule" : lambda s, i: s,

--- a/iit/model_pairs/iit_behavior_model_pair.py
+++ b/iit/model_pairs/iit_behavior_model_pair.py
@@ -19,12 +19,12 @@ class IITBehaviorModelPair(IITModelPair):
             training_args: dict = {}
             ):
         default_training_args = {
-            "lr": 0.001,
             "atol": 5e-2,
-            "early_stop": True,
             "use_single_loss": False,
             "iit_weight": 1.0,
             "behavior_weight": 1.0,
+            "iit_weight_schedule" : lambda s, i: s,
+            "behavior_weight_schedule" : lambda s, i: s, 
         }
         training_args = {**default_training_args, **training_args}
         super().__init__(hl_model, ll_model, corr=corr, training_args=training_args)
@@ -159,3 +159,7 @@ class IITBehaviorModelPair(IITModelPair):
         else:
             return super()._check_early_stop_condition(test_metrics)
         return False
+    
+    def _run_epoch_extras(self, epoch_number: int) -> None:
+        self.training_args['iit_weight'] = self.training_args['iit_weight_schedule'](self.training_args['iit_weight'], epoch_number)
+        self.training_args['behavior_weight'] = self.training_args['behavior_weight_schedule'](self.training_args['behavior_weight'], epoch_number)

--- a/iit/model_pairs/iit_behavior_model_pair.py
+++ b/iit/model_pairs/iit_behavior_model_pair.py
@@ -139,12 +139,13 @@ class IITBehaviorModelPair(IITModelPair):
                 iias.append(IIA)
                 losses.append(loss)
             IIA = sum(iias) / len(iias)
-            loss = t.cat(losses).mean()
+            loss = t.stack(losses).mean()
         else:
             raise ValueError(f"Invalid val_IIA_sampling: {self.training_args['val_IIA_sampling']}")
 
         # compute behavioral accuracy
         base_x, base_y = base_input[0:2]
+        base_y = base_y.to(self.ll_model.device) # so that input data doesn't all need to be hogging room on device.
         output = self.ll_model(base_x)
         if self.hl_model.is_categorical():
             top1 = t.argmax(output, dim=-1)

--- a/iit/model_pairs/iit_model_pair.py
+++ b/iit/model_pairs/iit_model_pair.py
@@ -127,9 +127,3 @@ class IITModelPair(BaseModelPair):
         loss.backward() # type: ignore
         optimizer.step()
         return {"train/iit_loss": loss.item()}
-
-
-    def _run_epoch_extras(self, epoch_number: int) -> None:
-        self.training_args['iit_weight'] = self.training_args['iit_weight_schedule'](self.training_args['iit_weight'], epoch_number)
-        self.training_args['strict_weight'] = self.training_args['strict_weight_schedule'](self.training_args['strict_weight'], epoch_number)
-        self.training_args['behavior_weight'] = self.training_args['behavior_weight_schedule'](self.training_args['behavior_weight'], epoch_number)

--- a/iit/model_pairs/iit_model_pair.py
+++ b/iit/model_pairs/iit_model_pair.py
@@ -38,7 +38,6 @@ class IITModelPair(BaseModelPair):
             "optimizer_cls": t.optim.Adam,
             "optimizer_kwargs" : {
                 "lr": 0.001,
-                "betas": (0.9, 0.9)
             },
         }
         training_args = {**default_training_args, **training_args}

--- a/iit/model_pairs/iit_model_pair.py
+++ b/iit/model_pairs/iit_model_pair.py
@@ -36,6 +36,9 @@ class IITModelPair(BaseModelPair):
             "clip_grad_norm": 1.0,
             "seed": 0,
             "detach_while_caching": True,
+            "iit_weight_schedule" : lambda s, i: s,
+            "strict_weight_schedule" : lambda s, i: s,
+            "behavior_weight_schedule" : lambda s, i: s,
         }
         training_args = {**default_training_args, **training_args}
         if isinstance(ll_model, HookedRootModule):
@@ -124,3 +127,9 @@ class IITModelPair(BaseModelPair):
         loss.backward() # type: ignore
         optimizer.step()
         return {"train/iit_loss": loss.item()}
+
+
+    def _run_epoch_extras(self, epoch_number: int) -> None:
+        self.training_args['iit_weight'] = self.training_args['iit_weight_schedule'](self.training_args['iit_weight'], epoch_number)
+        self.training_args['strict_weight'] = self.training_args['strict_weight_schedule'](self.training_args['strict_weight'], epoch_number)
+        self.training_args['behavior_weight'] = self.training_args['behavior_weight_schedule'](self.training_args['behavior_weight'], epoch_number)

--- a/iit/model_pairs/iit_model_pair.py
+++ b/iit/model_pairs/iit_model_pair.py
@@ -26,21 +26,21 @@ class IITModelPair(BaseModelPair):
         assert all([str(k) in self.hl_model.hook_dict for k in self.corr.keys()])
         default_training_args = {
             "batch_size": 256,
-            "lr": 0.001,
             "num_workers": 0,
             "early_stop": True,
             "lr_scheduler": None,
             "scheduler_val_metric": ["val/accuracy", "val/IIA"],
             "scheduler_mode": "max",
             "scheduler_kwargs": {},
+            "optimizer_kwargs" : {
+                "lr": 0.001,
+            },
             "clip_grad_norm": 1.0,
             "seed": 0,
             "detach_while_caching": True,
-            "iit_weight_schedule" : lambda s, i: s,
-            "strict_weight_schedule" : lambda s, i: s,
-            "behavior_weight_schedule" : lambda s, i: s,
         }
         training_args = {**default_training_args, **training_args}
+        
         if isinstance(ll_model, HookedRootModule):
             ll_model = LLModel.make_from_hooked_transformer(
                 ll_model, detach_while_caching=training_args["detach_while_caching"]

--- a/iit/model_pairs/iit_model_pair.py
+++ b/iit/model_pairs/iit_model_pair.py
@@ -32,12 +32,14 @@ class IITModelPair(BaseModelPair):
             "scheduler_val_metric": ["val/accuracy", "val/IIA"],
             "scheduler_mode": "max",
             "scheduler_kwargs": {},
-            "optimizer_kwargs" : {
-                "lr": 0.001,
-            },
             "clip_grad_norm": 1.0,
             "seed": 0,
             "detach_while_caching": True,
+            "optimizer_cls": t.optim.Adam,
+            "optimizer_kwargs" : {
+                "lr": 0.001,
+                "betas": (0.9, 0.9)
+            },
         }
         training_args = {**default_training_args, **training_args}
         

--- a/iit/model_pairs/iit_model_pair.py
+++ b/iit/model_pairs/iit_model_pair.py
@@ -23,8 +23,6 @@ class IITModelPair(BaseModelPair):
         self.hl_model.requires_grad_(False)
 
         self.corr = corr
-        print(self.hl_model.hook_dict)
-        print(self.corr.keys())
         assert all([str(k) in self.hl_model.hook_dict for k in self.corr.keys()])
         default_training_args = {
             "batch_size": 256,
@@ -34,6 +32,7 @@ class IITModelPair(BaseModelPair):
             "lr_scheduler": None,
             "scheduler_val_metric": ["val/accuracy", "val/IIA"],
             "scheduler_mode": "max",
+            "scheduler_kwargs": {},
             "clip_grad_norm": 1.0,
             "seed": 0,
             "detach_while_caching": True,

--- a/iit/model_pairs/probed_sequential_pair.py
+++ b/iit/model_pairs/probed_sequential_pair.py
@@ -82,7 +82,6 @@ class IITProbeSequentialPair(IITModelPair):
         self,
         train_set: IITDataset,
         test_set: IITDataset,
-        optimizer_cls: Type[t.optim.Optimizer] = t.optim.Adam,
         epochs: int = 1000,
         use_wandb: bool = False,
         wandb_name_suffix: str = "",
@@ -107,9 +106,9 @@ class IITProbeSequentialPair(IITModelPair):
         for p in probes.values():
             params += list(p.parameters())
         optimizer_kwargs['lr'] = training_args["lr"]
-        probe_optimizer = optimizer_cls(params, **optimizer_kwargs)
+        probe_optimizer = training_args['optimizer_cls'](params, **optimizer_kwargs)
 
-        optimizer = optimizer_cls(self.ll_model.parameters(), **optimizer_kwargs)
+        optimizer = training_args['optimizer_cls'](self.ll_model.parameters(), **optimizer_kwargs)
         loss_fn = t.nn.CrossEntropyLoss()
 
         if use_wandb and not wandb.run:

--- a/iit/model_pairs/strict_iit_model_pair.py
+++ b/iit/model_pairs/strict_iit_model_pair.py
@@ -22,7 +22,6 @@ class StrictIITModelPair(IITBehaviorModelPair):
             ):
         default_training_args = {
             "strict_weight": 1.0,
-            "strict_weight_schedule" : lambda s, i: s,
             "siit_sampling" : "individual", # individual, sample_all, all
         }
         training_args = {**default_training_args, **training_args}
@@ -133,9 +132,9 @@ class StrictIITModelPair(IITBehaviorModelPair):
             self.step_on_loss(total_loss, optimizer)
 
         return {
-            "train/iit_loss": iit_loss.item() if isinstance(iit_loss, Tensor) else iit_loss,
-            "train/behavior_loss": behavior_loss.item() if isinstance(behavior_loss, Tensor) else behavior_loss,
-            "train/strict_loss": siit_loss.item() if isinstance(siit_loss, Tensor) else siit_loss,
+            "train/iit_loss": iit_loss.item(),
+            "train/behavior_loss": behavior_loss.item(),
+            "train/strict_loss": siit_loss.item(),
         }
 
     def run_eval_step(
@@ -191,8 +190,3 @@ class StrictIITModelPair(IITBehaviorModelPair):
             if metric.get_name() == "val/IIA" and self.training_args["iit_weight"] > 0:
                 metrics_to_check.append(metric)
         return super()._check_early_stop_condition(MetricStoreCollection(metrics_to_check))
-    
-
-    def _run_epoch_extras(self, epoch_number: int) -> None:
-        super()._run_epoch_extras(epoch_number)
-        self.training_args['strict_weight'] = self.training_args['strict_weight_schedule'](self.training_args['strict_weight'], epoch_number)

--- a/iit/model_pairs/strict_iit_model_pair.py
+++ b/iit/model_pairs/strict_iit_model_pair.py
@@ -55,7 +55,7 @@ class StrictIITModelPair(IITBehaviorModelPair):
         if self.training_args['siit_sampling'] == 'individual':
             ll_nodes = [self.rng.choice(np.array(self.nodes_not_in_circuit, dtype=object)),]
         elif self.training_args['siit_sampling'] == 'sample_all':
-            importance = t.randint(0, 2, (len(self.nodes_not_in_circuit),)).to(bool).tolist()
+            importance = t.randint(0, 2, (len(self.nodes_not_in_circuit),)).to(t.bool).tolist()
             ll_nodes = [node for node, imp in zip(self.nodes_not_in_circuit, importance) if imp]
         elif self.training_args['siit_sampling'] == 'all':
             ll_nodes = self.nodes_not_in_circuit
@@ -97,9 +97,9 @@ class StrictIITModelPair(IITBehaviorModelPair):
     ) -> dict:
         use_single_loss = self.training_args["use_single_loss"]
 
-        iit_loss = 0
-        ll_loss = 0
-        behavior_loss = 0
+        iit_loss = t.zeros(1)
+        siit_loss = t.zeros(1)
+        behavior_loss = t.zeros(1)
 
         if self.training_args["iit_weight"] > 0:
             hl_node = self.sample_hl_name()  # sample a high-level variable to ablate
@@ -118,7 +118,7 @@ class StrictIITModelPair(IITBehaviorModelPair):
             * self.training_args["strict_weight"]
         )
             if not use_single_loss:
-                self.step_on_loss(ll_loss, optimizer)
+                self.step_on_loss(siit_loss, optimizer)
 
         if self.training_args["behavior_weight"] > 0:
             behavior_loss = (

--- a/iit/model_pairs/strict_iit_model_pair.py
+++ b/iit/model_pairs/strict_iit_model_pair.py
@@ -21,14 +21,8 @@ class StrictIITModelPair(IITBehaviorModelPair):
             training_args: dict = {}
             ):
         default_training_args = {
-            "batch_size": 256,
-            "lr": 0.001,
-            "num_workers": 0,
-            "use_single_loss": False,
-            "iit_weight": 1.0,
-            "behavior_weight": 1.0,
             "strict_weight": 1.0,
-            "clip_grad_norm": 1.0,
+            "strict_weight_schedule" : lambda s, i: s,
             "siit_sampling" : "individual", # individual, sample_all, all
         }
         training_args = {**default_training_args, **training_args}
@@ -195,3 +189,8 @@ class StrictIITModelPair(IITBehaviorModelPair):
             if metric.get_name() == "val/IIA" and self.training_args["iit_weight"] > 0:
                 metrics_to_check.append(metric)
         return super()._check_early_stop_condition(MetricStoreCollection(metrics_to_check))
+    
+
+    def _run_epoch_extras(self, epoch_number: int) -> None:
+        super()._run_epoch_extras(epoch_number)
+        self.training_args['strict_weight'] = self.training_args['strict_weight_schedule'](self.training_args['strict_weight'], epoch_number)

--- a/iit/utils/tqdm.py
+++ b/iit/utils/tqdm.py
@@ -1,0 +1,17 @@
+def in_notebook() -> bool:
+    try:
+        # This will only work in Jupyter notebooks
+        shell = get_ipython().__class__.__name__ # type: ignore
+        if shell == 'ZMQInteractiveShell':
+            return True  # Jupyter notebook or qtconsole
+        elif shell == 'TerminalInteractiveShell':
+            return False  # Terminal running IPython
+        else:
+            return False  # Other types of interactive shells
+    except NameError:
+        return False  # Probably standard Python interpreter
+    
+if in_notebook():
+    from tqdm.notebook import tqdm
+else:
+    from tqdm import tqdm


### PR DESCRIPTION
A bunch of small changes to make training smoother & a bit more robust; most importantly: 

- use_single_loss is now true and default optimizer arguments for Adam use beta = (0.9, 0.9), as opposed to (0.9, 0.999). I find that this makes training with a single loss step more robust, but please check this for your cases!
- progress bars are now reused during training and a log is output below them instead of them being recreated every epoch.
- removes redundancy between training_args definitions
- puts SIIT loss calculation into its own function like IIT loss.
- Changes how nodes are sampled for SIIT and makes this a training argument; now there's an option so that SIIT can randomly sample from all of the nodes that aren't in the circuit and ablate those, rather than just ablating one.

mypy type checking and pytest tests/ passes, but it's possible some downstream stuff broke? Unclear.