### PR TITLE
Remove hardcoded entity for iit training

### DIFF
--- a/iit/model_pairs/base_model_pair.py
+++ b/iit/model_pairs/base_model_pair.py
@@ -12,7 +12,6 @@ from transformer_lens.hook_points import HookedRootModule, HookPoint # type: ign
 import wandb # type: ignore
 from iit.model_pairs.ll_model import LLModel
 from iit.utils.nodes import HLNode, LLNode
-from iit.utils.config import WANDB_ENTITY
 from iit.utils.correspondence import Correspondence
 from iit.utils.iit_dataset import IITDataset
 from iit.utils.index import Ix, TorchIndex
@@ -223,7 +222,8 @@ class BaseModelPair(ABC):
         test_set: IITDataset,
         epochs: int = 1000,
         use_wandb: bool = False,
-        wandb_name_suffix: str = "",
+        wandb_project: str = "iit",
+        wandb_name: str = "",
     ) -> None:
         training_args = self.training_args
         print(f"{training_args=}")
@@ -287,8 +287,7 @@ class BaseModelPair(ABC):
             print("No LR scheduler set up")
 
         if use_wandb and not wandb.run:
-            wandb.init(project="iit", name=wandb_name_suffix, 
-                       entity=WANDB_ENTITY)
+            wandb.init(project=wandb_project, name=wandb_name)
 
         if use_wandb:
             wandb.config.update(training_args)

--- a/iit/model_pairs/probed_sequential_pair.py
+++ b/iit/model_pairs/probed_sequential_pair.py
@@ -8,7 +8,6 @@ from tqdm import tqdm # type: ignore
 from transformer_lens.hook_points import HookedRootModule #type: ignore
 
 from iit.model_pairs.iit_model_pair import IITModelPair
-from iit.utils.config import WANDB_ENTITY
 from iit.utils.probes import construct_probes #type: ignore
 from iit.utils.correspondence import Correspondence
 from iit.utils.iit_dataset import IITDataset
@@ -112,7 +111,7 @@ class IITProbeSequentialPair(IITModelPair):
         loss_fn = t.nn.CrossEntropyLoss()
 
         if use_wandb and not wandb.run:
-            wandb.init(project="iit", entity=WANDB_ENTITY)
+            wandb.init(project="iit")
 
         if use_wandb:
             wandb.config.update(training_args)

--- a/iit/model_pairs/probed_sequential_pair.py
+++ b/iit/model_pairs/probed_sequential_pair.py
@@ -83,7 +83,8 @@ class IITProbeSequentialPair(IITModelPair):
         test_set: IITDataset,
         epochs: int = 1000,
         use_wandb: bool = False,
-        wandb_name_suffix: str = "",
+        wandb_project: str = "iit",
+        wandb_name: str = "",
         optimizer_kwargs: dict = {},
     ) -> None:
         training_args = self.training_args
@@ -111,7 +112,7 @@ class IITProbeSequentialPair(IITModelPair):
         loss_fn = t.nn.CrossEntropyLoss()
 
         if use_wandb and not wandb.run:
-            wandb.init(project="iit")
+            wandb.init(project=wandb_project, name=wandb_name)
 
         if use_wandb:
             wandb.config.update(training_args)

--- a/iit/utils/config.py
+++ b/iit/utils/config.py
@@ -1,4 +1,3 @@
 import torch
 
 DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-WANDB_ENTITY = "cybershiptrooper" #TODO: This should be editable by the user at runtime


### PR DESCRIPTION
This hardcoded string prevents me from running IIT and sending it to my wandb. Also, there is no need to indicate the entity when calling `wandb.init`, since the wandb can automatically detect it based on the value of `WANDB_API_KEY` in env variables.